### PR TITLE
Avoid using the subscriber directly as elements of the subscriber lis…

### DIFF
--- a/pico-event/src/main/scala/org/pico/event/Wrapper.scala
+++ b/pico-event/src/main/scala/org/pico/event/Wrapper.scala
@@ -1,0 +1,3 @@
+package org.pico.event
+
+case class Wrapper[A](target: A)


### PR DESCRIPTION
…t to facilitat garbage collection
